### PR TITLE
Bump Native SDKs to v11

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -16,7 +16,7 @@
       }
     },
     "..": {
-      "version": "9.1.7",
+      "version": "11.0.0",
       "dev": true,
       "license": "Apache 2.0 License"
     },

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="instabug-cordova"
-        version="9.1.7">
+        version="11.0.0">
 
     <name>instabug-cordova</name>
 
@@ -77,7 +77,7 @@
             <uses-permission android:name="android.permission.INTERNET"/>
         </config-file>
 
-        <framework src="com.instabug.library:instabug:10.13.0"/>
+        <framework src="com.instabug.library:instabug:11.2.0"/>
 
         <source-file src="src/android/IBGPluginActivity.java" target-dir="src/com/instabug/cordova/plugin"/>
         <source-file src="src/android/IBGPlugin.java" target-dir="src/com/instabug/cordova/plugin"/>
@@ -98,7 +98,7 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="Instabug" spec="10.11.9" />
+                <pod name="Instabug" spec="11.0.2" />
             </pods>
         </podspec>
 

--- a/src/android/IBGPlugin.java
+++ b/src/android/IBGPlugin.java
@@ -881,25 +881,6 @@ public class IBGPlugin extends CordovaPlugin {
     }
 
     /**
-     * Sets maximum auto screen recording video duration.
-     *
-     * @param args .optInt(0)        maximum duration of the screen recording video seconds
-     *                        The maximum duration is 30 seconds
-     *
-     * @param callbackContext Used when calling back into JavaScript
-     */
-    public void setAutoScreenRecordingMaxDuration(final CallbackContext callbackContext, JSONArray args) {
-        int duration = args.optInt(0);
-        try {
-            int durationInMilli = duration * 1000;
-            Instabug.setAutoScreenRecordingMaxDuration(durationInMilli);
-            callbackContext.success();
-        } catch (IllegalStateException e) {
-            callbackContext.error(errorMsg);
-        }
-    }
-
-    /**
      * Sets user attribute to overwrite it's value or create a new one if it doesn't
      * exist.
      *

--- a/src/android/IBGPlugin.java
+++ b/src/android/IBGPlugin.java
@@ -22,7 +22,6 @@ import com.instabug.library.OnSdkDismissCallback;
 import com.instabug.library.extendedbugreport.ExtendedBugReport;
 import com.instabug.library.internal.module.InstabugLocale;
 import com.instabug.library.invocation.InstabugInvocationEvent;
-import com.instabug.bug.invocation.InvocationMode;
 import com.instabug.library.invocation.OnInvokeCallback;
 import com.instabug.library.invocation.util.InstabugVideoRecordingButtonPosition;
 import com.instabug.library.logging.InstabugLog;
@@ -1224,25 +1223,6 @@ public class IBGPlugin extends CordovaPlugin {
         } else if ("addCommentToFeature".equals(actionType)) {
             return ActionType.ADD_COMMENT_TO_FEATURE;
         } else return -1;
-    }
-
-    /**
-     * Convenience method for converting string to InstabugInvocationMode.
-     *
-     * @param mode String shortcode for mode
-     */
-    public static InvocationMode parseInvocationMode(String mode) {
-        if ("chat".equals(mode)) {
-            return InvocationMode.NEW_CHAT;
-        } else if ("chats".equals(mode)) {
-            return InvocationMode.CHATS_LIST;
-        } else if ("bug".equals(mode)) {
-            return InvocationMode.NEW_BUG;
-        } else if ("feedback".equals(mode)) {
-            return InvocationMode.NEW_FEEDBACK;
-        } else if ("options".equals(mode)) {
-            return InvocationMode.PROMPT_OPTION;
-        } else return null;
     }
 
     /**

--- a/src/android/IBGPlugin.java
+++ b/src/android/IBGPlugin.java
@@ -1077,29 +1077,6 @@ public class IBGPlugin extends CordovaPlugin {
     }
 
     /**
-     * Set after how many sessions should the dismissed survey would show again.
-     *
-     * @param callbackContext Used when calling back into JavaScript
-     * @param args .optInt(0)   number of sessions that the dismissed survey will be
-     *                        shown after.
-     * @param args .optInt(1)       number of days that the dismissed survey will show
-     *                        after.
-     */
-    public void setThresholdForReshowingSurveyAfterDismiss(final CallbackContext callbackContext, JSONArray args) {
-        int sessionsCount = args.optInt(0);
-        int daysCount = args.optInt(1);
-        if (Math.signum(sessionsCount) != -1 && Math.signum(daysCount) != -1) {
-            try {
-                Surveys.setThresholdForReshowingSurveyAfterDismiss(sessionsCount, daysCount);
-                callbackContext.success();
-            } catch (IllegalStateException e) {
-                callbackContext.error(errorMsg);
-            }
-        } else
-            callbackContext.error("Session count and days count must be provided.");
-    }
-
-    /**
      * Shows the UI for feature requests list
      *
      * @param callbackContext Used when calling back into JavaScript

--- a/src/android/IBGPlugin.java
+++ b/src/android/IBGPlugin.java
@@ -852,12 +852,12 @@ public class IBGPlugin extends CordovaPlugin {
      * @param callbackContext Used when calling back into JavaScript
      */
     public void setViewHierarchyEnabled(final CallbackContext callbackContext, JSONArray args) {
-        Boolean isEnabled = args.optBoolean(0);
+        boolean isEnabled = args.optBoolean(0);
         try {
             if (isEnabled) {
-                Instabug.setViewHierarchyState(Feature.State.ENABLED);
+                BugReporting.setViewHierarchyState(Feature.State.ENABLED);
             } else {
-                Instabug.setViewHierarchyState(Feature.State.DISABLED);
+                BugReporting.setViewHierarchyState(Feature.State.DISABLED);
             }
             callbackContext.success();
         } catch (IllegalStateException e) {

--- a/src/ios/IBGPlugin.m
+++ b/src/ios/IBGPlugin.m
@@ -275,12 +275,13 @@
  */
 - (void) hasRespondedToSurveyWithToken:(CDVInvokedUrlCommand*)command
  {
-     CDVPluginResult* result;
+     __block CDVPluginResult* result;
      NSString *surveyToken = [command argumentAtIndex:0];
 
      if (surveyToken.length > 0) {
-         result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
-                                    messageAsBool:[IBGSurveys hasRespondedToSurveyWithToken:surveyToken]];
+         [IBGSurveys hasRespondedToSurveyWithToken:surveyToken completionHandler:^(BOOL hasResponded) {
+            result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:hasResponded];
+         }];
      } else {
          result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
                                     messageAsString:@"A non-empty survey token must be provided."];

--- a/src/ios/IBGPlugin.m
+++ b/src/ios/IBGPlugin.m
@@ -776,7 +776,7 @@
      BOOL isEnabled = [command argumentAtIndex:0];
 
      if (isEnabled) {
-         Instabug.shouldCaptureViewHierarchy = [[command argumentAtIndex:0] boolValue];
+         IBGBugReporting.shouldCaptureViewHierarchy = [[command argumentAtIndex:0] boolValue];
          result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
      } else {
          result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR

--- a/src/ios/IBGPlugin.m
+++ b/src/ios/IBGPlugin.m
@@ -1449,7 +1449,7 @@
     } else if ([locale isEqualToString:@"polish"]) {
         return IBGLocalePolish;
     } else if ([locale isEqualToString:@"portuguese"]) {
-        return IBGLocalePortugese;
+        return IBGLocalePortuguese;
     } else if ([locale isEqualToString:@"portugueseBrazil"]) {
         return IBGLocalePortugueseBrazil;
     } else if ([locale isEqualToString:@"russian"]) {

--- a/src/ios/IBGPlugin.m
+++ b/src/ios/IBGPlugin.m
@@ -833,29 +833,6 @@
         [self.commandDelegate sendPluginResult:result callbackId:[command callbackId]];
     }
 
-  /**
-   * Sets maximum auto screen recording video duration.
-   *
-   * @param {CDVInvokedUrlCommand*} command
-   *        The command sent from JavaScript
-   */
-   - (void) setAutoScreenRecordingMaxDuration:(CDVInvokedUrlCommand*)command
-   {
-       CDVPluginResult* result;
-
-       CGFloat duration = [[command argumentAtIndex:0] floatValue];
-
-       if (duration) {
-           Instabug.autoScreenRecordingDuration = duration;
-           result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-       } else {
-           result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
-                                      messageAsString:@"A duration must be provided."];
-       }
-
-       [self.commandDelegate sendPluginResult:result callbackId:[command callbackId]];
-   }
-
    /**
     * Returns the number of unread messages the user currently has.
     *

--- a/src/ios/IBGPlugin.m
+++ b/src/ios/IBGPlugin.m
@@ -1018,31 +1018,6 @@
     [self.commandDelegate sendPluginResult:result callbackId:[command callbackId]];
 }
 
-/**
- * Sets a threshold for numbers of sessions and another for number of days
- * required before a survey, that has been dismissed once, would show again.
- *
- * @param {CDVInvokedUrlCommand*} command
- *        The command sent from JavaScript
- */
- - (void) setThresholdForReshowingSurveyAfterDismiss:(CDVInvokedUrlCommand*)command
- {
-     CDVPluginResult* result;
-
-     NSInteger sessionsCount = [[command argumentAtIndex:0] integerValue];
-     NSInteger daysCount = [[command argumentAtIndex:1] integerValue];
-
-     if (sessionsCount && daysCount) {
-         [IBGSurveys setThresholdForReshowingSurveyAfterDismiss:sessionsCount daysCount:daysCount];
-         result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-     } else {
-         result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
-                                    messageAsString:@"A sessions count and days count must be provided."];
-     }
-
-     [self.commandDelegate sendPluginResult:result callbackId:[command callbackId]];
- }
-
  /**
   * Sets a threshold for numbers of sessions and another for number of days
   * required before a survey, that has been dismissed once, would show again.

--- a/src/ios/IBGPlugin.m
+++ b/src/ios/IBGPlugin.m
@@ -1300,28 +1300,6 @@
 
 /**
  * Convenience method for converting NSString to
- * IBGInvocationMode.
- *
- * @param  {NSString*}
- *         NSString shortcode for IBGInvocationMode
- */
-- (IBGInvocationMode) parseInvocationMode:(NSString*)mode
-{
-    if ([mode isEqualToString:@"bug"]) {
-        return IBGInvocationModeNewBug;
-    } else if ([mode isEqualToString:@"feedback"]) {
-        return IBGInvocationModeNewFeedback;
-    } else if ([mode isEqualToString:@"chat"]) {
-        return IBGInvocationModeNewChat;
-    } else if ([mode isEqualToString:@"chatList"]) {
-        return IBGInvocationModeChatsList;
-    } else if ([mode isEqualToString:@"na"]) {
-        return IBGInvocationModeNA;
-    } else return 0;
-}
-
-/**
- * Convenience method for converting NSString to
  * IBGPosition.
  *
  * @param  {NSString*} position

--- a/www/BugReporting.js
+++ b/www/BugReporting.js
@@ -131,6 +131,17 @@ BugReporting.showWithOptions = function(reportType, options, success, error) {
 };
 
 /**
+ * Enables or disables view hierarchy.
+ * 
+ * @param {boolean} enabled
+ * @param {function(void):void} success callback on function success
+ * @param {function(void):void} error callback on function error
+ */
+BugReporting.setViewHierarchyEnabled = function (enabled, success, error) {
+  exec(success, error, 'IBGPlugin', 'setViewHierarchyEnabled', [enabled]);
+};
+
+/**
  * Sets the invocation options.
  * Default is set by `Instabug.start`.
  * @param {enum} options Array of Option

--- a/www/BugReporting.js
+++ b/www/BugReporting.js
@@ -35,21 +35,6 @@ var getOptions = function() {
 };
 
 /**
- * The mode used upon invocating the SDK
- * @readonly
- * @enum {string} InvocationMode
- */
-var getInvocationModes = function() {
-  return {
-    chat: 'chat',
-    chats: 'chats',
-    bug: 'bug',
-    feedback: 'feedback',
-    options: 'options'
-  };
-};
-
-/**
  * The extended bug report mode.
  * @readonly
  * @enum {string} ExtendedBugReportMode
@@ -78,7 +63,6 @@ var BugReporting = function() {};
 
 BugReporting.invocationEvents = getInvocationEvents();
 BugReporting.option = getOptions();
-BugReporting.invocationModes = getInvocationModes();
 BugReporting.extendedBugReportMode = getExtendedBugReportMode();
 BugReporting.reportType = getReportType();
 

--- a/www/Instabug.js
+++ b/www/Instabug.js
@@ -73,10 +73,6 @@ Instabug.setPrimaryColor = function (colorInteger, success, error) {
     exec(success, error, 'IBGPlugin', 'setPrimaryColor', [colorInteger]);
 };
 
-Instabug.setAutoScreenRecordingMaxDuration = function (duration, success, error) {
-    exec(success, error, 'IBGPlugin', 'setAutoScreenRecordingMaxDuration', [duration]);
-};
-
 Instabug.logUserEventWithName = function (userEvent, success, error) {
     exec(success, error, 'IBGPlugin', 'logUserEventWithName', [userEvent]);
 };

--- a/www/Instabug.js
+++ b/www/Instabug.js
@@ -73,10 +73,6 @@ Instabug.setPrimaryColor = function (colorInteger, success, error) {
     exec(success, error, 'IBGPlugin', 'setPrimaryColor', [colorInteger]);
 };
 
-Instabug.setViewHierarchyEnabled = function (enabled, success, error) {
-    exec(success, error, 'IBGPlugin', 'setViewHierarchyEnabled', [enabled]);
-};
-
 Instabug.setAutoScreenRecordingMaxDuration = function (duration, success, error) {
     exec(success, error, 'IBGPlugin', 'setAutoScreenRecordingMaxDuration', [duration]);
 };

--- a/www/Surveys.js
+++ b/www/Surveys.js
@@ -84,20 +84,6 @@ Surveys.showSurveyWithToken = function (surveyToken, success, error) {
 };
 
 /**
- * Sets a threshold for numbers of sessions and another for number of days
- * required before a survey, that has been dismissed once, would show again.
- * @param {number} sessionsCount Number of sessions required to be
- *                initialized before a dismissed survey can be shown again.
- * @param {number} daysCount Number of days required to pass before a
- *                dismissed survey can be shown again.
- * @param {function():void} success 
- * @param {function(string):void} error 
- */
-Surveys.setThresholdForReshowingSurveyAfterDismiss = function (sessionsCount, daysCount, success, error) {
-    exec(success, error, 'IBGPlugin', 'setThresholdForReshowingSurveyAfterDismiss', [sessionsCount, daysCount]);
-};
-
-/**
  * Returns true if the survey with a specific token was answered before.
  * Will return false if the token does not exist or if the survey was not answered before.
  * @param {string} surveyToken a string with a survey token.


### PR DESCRIPTION
## Description of the change

- Bump Android SDK to v11.2.0.
- Bump iOS SDK to v11.0.2.

## Breaking changes

1. Remove `Instabug.setAutoScreenRecordingMaxDuration`
1. Remove `Surveys.setThresholdForReshowingSurveyAfterDismiss`
1. Remove `BugReporting.invocationModes` enum.
1. Move `Instabug.setViewHierarchyEnabled` to `BugReporting.setViewHierarchyEnabled`

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
