### PR TITLE
Fix `Instabug.addFile` on iOS

### DIFF
--- a/src/ios/IBGPlugin.m
+++ b/src/ios/IBGPlugin.m
@@ -422,13 +422,13 @@
     }
 
     if ([filePath length] > 0) {
-        NSFileManager* fileManager = [NSFileManager defaultManager];
+        NSError* err;
+        NSURL* url = [NSURL URLWithString:filePath];
 
-        if ([fileManager fileExistsAtPath:filePath]) {
+        if ([url checkResourceIsReachableAndReturnError:&err] == YES) {
             // If the file doesn't exist at the path specified,
             // we won't be able to notify the containing app when
             // Instabug API call fails, so we check ourselves.
-            NSURL* url = [NSURL URLWithString:filePath];
             [Instabug addFileAttachmentWithURL:url];
             result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
         } else {


### PR DESCRIPTION
## Description of the change

Use `NSURL` instead of `NSFileManager`.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
