### PR TITLE
Add `BugReporting.setEnabledAttachmentTypes` on Android

### DIFF
--- a/src/android/IBGPlugin.java
+++ b/src/android/IBGPlugin.java
@@ -992,6 +992,29 @@ public class IBGPlugin extends CordovaPlugin {
     }
 
     /**
+     * Customize the attachment options available to users to send with a bug reeport.
+     *
+     * @param callbackContext Used when calling back into JavaScript
+     * @param args .optBoolean(0)           whether or not to include an initial screenshot
+     * @param args .optBoolean(1)           whether or not to allow attaching additional screenshots
+     * @param args .optBoolean(2)           whether or not to allow attaching images from the gallery
+     * @param args .optBoolean(3)           whether or not to allow recording the screen
+     */
+    public void setAttachmentTypesEnabled(final CallbackContext callbackContext, JSONArray args) {
+        Boolean initialScreenshot = args.optBoolean(0);
+        Boolean extraScreenshot = args.optBoolean(1);
+        Boolean galleryImage = args.optBoolean(2);
+        Boolean screenRecording = args.optBoolean(3);
+        try {
+            // Arguments:initialScreenshot, extraScreenshot, galleryImage & ScreenRecording
+            BugReporting.setAttachmentTypesEnabled(initialScreenshot, extraScreenshot, galleryImage, screenRecording);
+            callbackContext.success();
+        } catch (IllegalStateException e) {
+            callbackContext.error(errorMsg);
+        }
+    }
+
+    /**
      * Sets whether the extended bug report mode should be disabled, enabled with
      * required fields or enabled with optional fields.
      *


### PR DESCRIPTION
## Description of the change

Add native implementation of `BugReporting.setEnabledAttachmentTypes` on Android.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 


[MOB-7706]: https://instabug.atlassian.net/browse/MOB-7706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ