### PR TITLE
Make `Instabug.start` ES5-compatible

### DIFF
--- a/www/Instabug.js
+++ b/www/Instabug.js
@@ -73,8 +73,8 @@ Instabug.strings = registry.strings;
  * @param {function(string):void} error callback on function error
  */
 Instabug.start = function (token, invocationEvents, success, error) {
-    const validEvents = getInvocationEvents();
-    const isValid = invocationEvents.every((e) => validEvents[e]);
+    var validEvents = getInvocationEvents();
+    var isValid = invocationEvents.every((e) => validEvents[e]);
 
     if (isValid && invocationEvents.length > 0) {
         exec(success, error, 'IBGPlugin', 'start', [token, invocationEvents]);


### PR DESCRIPTION
## Description of the change

Remove `const` usages.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
