### PR TITLE
Remove Unsupported APIs

### DIFF
--- a/src/android/IBGPlugin.java
+++ b/src/android/IBGPlugin.java
@@ -837,22 +837,6 @@ public class IBGPlugin extends CordovaPlugin {
     }
 
     /**
-     * Enabled/disable push notifications
-     *
-     * @param callbackContext Used when calling back into JavaScript
-     * @param args [isEnabled: boolean]
-     */
-    public void setPushNotificationsEnabled(final CallbackContext callbackContext, JSONArray args) {
-        try {
-            boolean isEnabled = args.optBoolean(0);
-            Replies.setPushNotificationState(isEnabled ? Feature.State.ENABLED : Feature.State.DISABLED);
-            callbackContext.success();
-        } catch (Exception e) {
-            callbackContext.error(e.getMessage());
-        }
-    }
-
-    /**
      * Enable/Disable view hierarchy from Instabug SDK
      *
      * @param args .optBoolean(0)       whether view hierarchy should be enabled or not

--- a/src/android/IBGPlugin.java
+++ b/src/android/IBGPlugin.java
@@ -1053,22 +1053,6 @@ public class IBGPlugin extends CordovaPlugin {
     }
 
     /**
-     * Sets whether to track the user’s steps while using the app or not.
-     *
-     * @param callbackContext Used when calling back into JavaScript
-     * @param args [isEnabled: boolean]
-     */
-    public void setTrackUserStepsEnabled(final CallbackContext callbackContext, JSONArray args) {
-        try {
-            boolean isEnabled = args.optBoolean(0);
-            Instabug.setTrackingUserStepsState(isEnabled ? Feature.State.ENABLED : Feature.State.DISABLED);
-            callbackContext.success();
-        } catch (Exception e) {
-            callbackContext.error(e.getMessage());
-        }
-    }
-
-    /**
      * Sets whether to enable the session profiler or not.
      *
      * @param callbackContext Used when calling back into JavaScript

--- a/src/android/IBGPlugin.java
+++ b/src/android/IBGPlugin.java
@@ -837,27 +837,6 @@ public class IBGPlugin extends CordovaPlugin {
     }
 
     /**
-     * Enable/Disable view hierarchy from Instabug SDK
-     *
-     * @param args .optBoolean(0)       whether view hierarchy should be enabled or not
-     *
-     * @param callbackContext Used when calling back into JavaScript
-     */
-    public void setViewHierarchyEnabled(final CallbackContext callbackContext, JSONArray args) {
-        boolean isEnabled = args.optBoolean(0);
-        try {
-            if (isEnabled) {
-                BugReporting.setViewHierarchyState(Feature.State.ENABLED);
-            } else {
-                BugReporting.setViewHierarchyState(Feature.State.DISABLED);
-            }
-            callbackContext.success();
-        } catch (IllegalStateException e) {
-            callbackContext.error(errorMsg);
-        }
-    }
-
-    /**
      * Shows one of the surveys that were not shown before, that also have conditions that
      * match the current device/user.
      *

--- a/src/ios/IBGPlugin.m
+++ b/src/ios/IBGPlugin.m
@@ -921,21 +921,6 @@
 }
 
 /**
- * Sets whether to allow the SDK to use push notifications or not.
- *
- * @param {CDVInvokedUrlCommand*} command
- *        The command sent from JavaScript
- */
-- (void) setPushNotificationsEnabled:(CDVInvokedUrlCommand*)command
-{
-    bool enabled = [[command argumentAtIndex:0] boolValue];
-    [IBGReplies setPushNotificationsEnabled:enabled];
-
-    [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK]
-                            callbackId:[command callbackId]];
-}
-
-/**
  * Sets whether to enable the session profiler or not.
  *
  * @param {CDVInvokedUrlCommand*} command

--- a/src/ios/IBGPlugin.m
+++ b/src/ios/IBGPlugin.m
@@ -769,29 +769,6 @@
     [self.commandDelegate sendPluginResult:result callbackId:[command callbackId]];
 }
 
-/**
- * Enable/Disable view hierarchy from Instabug SDK
- *
- * @param {CDVInvokedUrlCommand*} command
- *        The command sent from JavaScript
- */
- - (void) setViewHierarchyEnabled:(CDVInvokedUrlCommand*)command
- {
-     CDVPluginResult* result;
-
-     BOOL isEnabled = [command argumentAtIndex:0];
-
-     if (isEnabled) {
-         IBGBugReporting.shouldCaptureViewHierarchy = [[command argumentAtIndex:0] boolValue];
-         result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-     } else {
-         result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
-                                    messageAsString:@"A boolean value must be provided."];
-     }
-
-     [self.commandDelegate sendPluginResult:result callbackId:[command callbackId]];
- }
-
   /**
    * Enables/disables showing in-app notifications when the user receives a new
    * message.

--- a/src/ios/IBGPlugin.m
+++ b/src/ios/IBGPlugin.m
@@ -906,21 +906,6 @@
 }
 
 /**
- * Sets whether to track the user’s steps while using the app or not.
- *
- * @param {CDVInvokedUrlCommand*} command
- *        The command sent from JavaScript
- */
-- (void) setTrackUserStepsEnabled:(CDVInvokedUrlCommand*)command
-{
-    bool enabled = [[command argumentAtIndex:0] boolValue];
-    Instabug.trackUserSteps = enabled;
-
-    [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK]
-                            callbackId:[command callbackId]];
-}
-
-/**
  * Sets whether to enable the session profiler or not.
  *
  * @param {CDVInvokedUrlCommand*} command

--- a/www/BugReporting.js
+++ b/www/BugReporting.js
@@ -117,17 +117,6 @@ BugReporting.showWithOptions = function(reportType, options, success, error) {
 };
 
 /**
- * Enables or disables view hierarchy.
- * 
- * @param {boolean} enabled
- * @param {function(void):void} success callback on function success
- * @param {function(void):void} error callback on function error
- */
-BugReporting.setViewHierarchyEnabled = function (enabled, success, error) {
-  exec(success, error, 'IBGPlugin', 'setViewHierarchyEnabled', [enabled]);
-};
-
-/**
  * Sets the invocation options.
  * Default is set by `Instabug.start`.
  * @param {enum} options Array of Option

--- a/www/Instabug.js
+++ b/www/Instabug.js
@@ -152,20 +152,6 @@ Instabug.setReproStepsMode = function (reproStepsMode, success, error) {
 };
 
 /**
- * Sets whether the SDK is tracking user steps or not.
- * Enabling user steps would give you an insight on the scenario a user has
- * performed before encountering a bug or a crash. User steps are attached
- * with each report being sent.
- * @param {boolean} isEnabled A boolean to set user steps tracking
- * to being enabled or disabled.
- * @param {function} success callback on function success
- * @param {function(string):void} error callback on function error
- */
-Instabug.setTrackUserStepsEnabled = function (isEnabled, success, error) {
-    exec(success, error, 'IBGPlugin', 'setTrackUserStepsEnabled', [isEnabled]);
-};
-
-/**
  * Sets the welcome message mode to live, beta or disabled.
  * @param {keyof Instabug.welcomeMessageMode} mode.
  * @param {function} success callback on function success

--- a/www/Replies.js
+++ b/www/Replies.js
@@ -58,15 +58,4 @@ Replies.setInAppNotificationEnabled = function (isEnabled, success, error) {
     exec(success, error, 'IBGPlugin', 'setChatNotificationEnabled', [isEnabled]);
 };
 
-/**
- * Enables/disables the use of push notifications in the SDK.
- * Defaults to YES.
- * @param {boolean} isEnabled
- * @param {function(void):void} success callback on function success
- * @param {function(void):void} error callback on function error
- */
-Replies.setPushNotificationsEnabled = function (isEnabled, success, error) {
-    exec(success, error, 'IBGPlugin', 'setPushNotificationsEnabled', [isEnabled]);
-};
-
 module.exports = Replies;


### PR DESCRIPTION
## Description of the change

Remove some APIs that are currently not supported.

- [x] `Instabug.setTrackUserStepsEnabled`
- [x] `BugReporting.setViewHierarchyEnabled`
- [x] `Replies.setPushNotificationsEnabled`

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
