### PR TITLE
[MOB-9117] Fix typo in Instabug.setPrimaryColor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## master
+
+* Fixes a typo in Instabug.setPrimaryColor causing the API not to work
+
 ## v11.0.0 (2022-07-07)
 
 * Bumps Instabug native SDKs to v11

--- a/www/Instabug.js
+++ b/www/Instabug.js
@@ -104,7 +104,7 @@ Instabug.show = function (success, error) {
  * @param {function(string):void} error callback on function error
  */
 Instabug.setPrimaryColor = function (color, success, error) {
-    exec(success, error, 'IBGPlugin', 'setPrimaryColor', [colorInteger]);
+    exec(success, error, 'IBGPlugin', 'setPrimaryColor', [color]);
 };
 
 /**


### PR DESCRIPTION
## Description of the change
- Fixes a typo in `color` parameter causing the API not to work
## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request 
