### PR TITLE
[MOB-9755] Fix `ArgsRegistry` Import on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Fix ArgsRegistry import on iOS.
+
 ## v11.0.0 (2022-07-07)
 
 * Bumps Instabug native SDKs to v11

--- a/plugin.xml
+++ b/plugin.xml
@@ -99,8 +99,8 @@
         <header-file src="src/ios/IBGPlugin.h" />
         <source-file src="src/ios/IBGPlugin.m" />
 
-        <header-file src="src//ios/util/ArgsRegistry.h" target-dir="util" />
-        <source-file src="src/ios/util/ArgsRegistry.m" target-dir="util" />
+        <header-file src="src//ios/util/ArgsRegistry.h" />
+        <source-file src="src/ios/util/ArgsRegistry.m" />
     </platform>
 
 </plugin>

--- a/src/ios/IBGPlugin.h
+++ b/src/ios/IBGPlugin.h
@@ -1,5 +1,5 @@
 #import <Cordova/CDVPlugin.h>
-#import "util/ArgsRegistry.h"
+#import "ArgsRegistry.h"
 
 @interface IBGPlugin : CDVPlugin
 


### PR DESCRIPTION
## Description of the change

Flatten the iOS Project structure, by removing the `util` directory.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
