### PR TITLE
Fix Email `EditText`'s `ViewMatcher`

### DIFF
--- a/example/tests/src/android/androidTest/InvokeInstabugUITest.java
+++ b/example/tests/src/android/androidTest/InvokeInstabugUITest.java
@@ -3,8 +3,11 @@ package com.instabug.example;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.replaceText;
+import static androidx.test.espresso.matcher.ViewMatchers.withParent;
 import static androidx.test.espresso.matcher.ViewMatchers.withResourceName;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
+
+import static org.hamcrest.Matchers.allOf;
 
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -23,10 +26,17 @@ public class InvokeInstabugUITest {
     @Test
     public void ensureInstabugInvocation() throws InterruptedException {
         Thread.sleep(5000);
-        onView(withResourceName("instabug_floating_button")).perform(click());
 
+        onView(withResourceName("instabug_floating_button")).perform(click());
         onView(withText("Report a bug")).perform(click());
-        onView(withResourceName("instabug_edit_text_email")).perform(replaceText("inst@bug.com"));
+
+        onView(
+                allOf(
+                        withResourceName("ib_edit_text"),
+                        withParent(withResourceName("instabug_edit_text_email"))
+                )
+        ).perform(replaceText("inst@bug.com"));
+
         onView(withResourceName("instabug_bugreporting_send")).perform(click());
         onView(withResourceName("instabug_success_dialog_container")).perform(click());
     }


### PR DESCRIPTION
## Description of the change

The UI test got broken after recent change in Android (v11.3.0+). 
References: Instabug/android#4035

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
