### PR TITLE
[MOB-10379] Bump Instabug Android SDK to `v11.5.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Bumps Instabug Android SDK to v11.5.1
+
 ## 11.2.0 (2022-09-25)
 
 * Bumps Instabug Android SDK to v11.4.1

--- a/plugin.xml
+++ b/plugin.xml
@@ -68,7 +68,7 @@
             <uses-permission android:name="android.permission.INTERNET"/>
         </config-file>
 
-        <framework src="com.instabug.library:instabug:11.4.1"/>
+        <framework src="com.instabug.library:instabug:11.5.1"/>
 
         <source-file src="src/android/IBGPlugin.java" target-dir="src/com/instabug/cordova/plugin"/>
         <source-file src="src/android/util/Util.java" target-dir="src/com/instabug/cordova/plugin/util"/>


### PR DESCRIPTION
## Description of the change

- Bumps Instabug Android SDK to v11.5.1

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request 
