### PR TITLE
[MOB-11697] Bump iOS SDK to `v11.7.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Bumps Instabug iOS SDK to `v11.7.0`
+
 ## 11.3.0 (2022-10-05)
 
 * Bumps Instabug Android SDK to v11.5.1

--- a/plugin.xml
+++ b/plugin.xml
@@ -89,7 +89,7 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="Instabug" spec="11.3.0" />
+                <pod name="Instabug" spec="11.7.0" />
             </pods>
         </podspec>
 


### PR DESCRIPTION
## Description of the change
- Bumps Instabug iOS SDK to `v11.7.0`
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request 
