### PR TITLE
[MOB-11698] Bump Android SDK to `v11.8.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Bumps Instabug Android SDK to `v11.8.0`
+
 ## 11.3.0 (2022-10-05)
 
 * Bumps Instabug Android SDK to v11.5.1

--- a/plugin.xml
+++ b/plugin.xml
@@ -68,7 +68,7 @@
             <uses-permission android:name="android.permission.INTERNET"/>
         </config-file>
 
-        <framework src="com.instabug.library:instabug:11.5.1"/>
+        <framework src="com.instabug.library:instabug:11.8.0"/>
 
         <source-file src="src/android/IBGPlugin.java" target-dir="src/com/instabug/cordova/plugin"/>
         <source-file src="src/android/util/Util.java" target-dir="src/com/instabug/cordova/plugin/util"/>

--- a/src/android/util/ArgsRegistry.java
+++ b/src/android/util/ArgsRegistry.java
@@ -77,7 +77,6 @@ public class ArgsRegistry {
         put("recordingMessageToHoldText", Key.VOICE_MESSAGE_PRESS_AND_HOLD_TO_RECORD);
         put("recordingMessageToReleaseText", Key.VOICE_MESSAGE_RELEASE_TO_ATTACH);
         put("thankYouText", Key.SUCCESS_DIALOG_HEADER);
-        put("video", Key.VIDEO_PLAYER_TITLE);
         put("videoPressRecord", Key.VIDEO_RECORDING_FAB_BUBBLE_HINT);
         put("conversationTextFieldHint", Key.CONVERSATION_TEXT_FIELD_HINT);
         put("thankYouAlertText", Key.REPORT_SUCCESSFULLY_SENT);

--- a/src/modules/ArgsRegistry.ts
+++ b/src/modules/ArgsRegistry.ts
@@ -56,7 +56,6 @@ namespace ArgsRegistry {
     cancelButtonText = "cancelButtonTitle",
     thankYouText = "thankYouText",
     audio = "audio",
-    video = "video",
     image = "image",
     team = "team",
     messagesNotification = "messagesNotification",


### PR DESCRIPTION
## Description of the change

- Bumps Instabug Android SDK to `v11.8.0`

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request 
