### PR TITLE
[MOB-11704] Add more Customization APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Bumps Instabug Android SDK to `v11.8.0`
 * Bumps Instabug iOS SDK to `v11.7.0`
+* Adds `BugReporting.setDisclaimerText` API
+* Adds `BugReporting.setCommentMinimumCharacterCount` API
 * Adds support for more locales:
   * czech
   * finnish

--- a/src/android/IBGPlugin.java
+++ b/src/android/IBGPlugin.java
@@ -999,6 +999,23 @@ public class IBGPlugin extends CordovaPlugin {
             callbackContext.error(e.getMessage());
         }
     }
+    
+    /**
+     * Sets a minimum number of characters as a requirement for the comments field in the different report types.
+     * @param callbackContext Used when calling back into JavaScript
+     * @param args [limit: int, reportTypes: reportTypes[]]
+     */
+    public void setCommentMinimumCharacterCount(final CallbackContext callbackContext, JSONArray args) {
+        final int limit = args.optInt(0);
+        final JSONArray reportTypes = args.optJSONArray(1);
+        final String[] stringArrayOfReportTypes = toStringArray(reportTypes);
+        try {
+            int [] parsedReportTypes = stringArrayOfReportTypes == null ? new int[0] : Util.parseReportTypes(stringArrayOfReportTypes);
+            BugReporting.setCommentMinimumCharacterCount(limit, parsedReportTypes);
+        } catch (Exception e) {
+            callbackContext.error(e.getMessage());
+        }
+    }
 
     /**
      * Customize the attachment options available to users to send with a bug reeport.

--- a/src/android/IBGPlugin.java
+++ b/src/android/IBGPlugin.java
@@ -985,6 +985,22 @@ public class IBGPlugin extends CordovaPlugin {
     }
 
     /**
+     * Adds a disclaimer text within the bug reporting form, which can include hyperlinked text.
+     * @param callbackContext Used when calling back into JavaScript
+     * @param args [text: String]
+     */
+    public void setDisclaimerText(final CallbackContext callbackContext, JSONArray args) {
+        final String text = args.optString(0);
+        try {
+            BugReporting.setDisclaimerText(text);
+
+            callbackContext.success();
+        } catch (Exception e) {
+            callbackContext.error(e.getMessage());
+        }
+    }
+
+    /**
      * Customize the attachment options available to users to send with a bug reeport.
      *
      * @param callbackContext Used when calling back into JavaScript

--- a/src/ios/IBGPlugin.m
+++ b/src/ios/IBGPlugin.m
@@ -393,6 +393,21 @@
 }
 
 /**
+ * Adds a disclaimer text within the bug reporting form, which can include hyperlinked text.
+ * @param {CDVInvokedUrlCommand*} command
+ *        The command sent from JavaScript
+ */
+- (void)setDisclaimerText:(CDVInvokedUrlCommand*)command
+{
+    NSString* text = [command argumentAtIndex:0];
+    
+    [IBGBugReporting setDisclaimerText:text];
+
+    [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK]
+                                callbackId:[command callbackId]];
+}
+
+/**
  * Attaches a new copy of this file with each bug report sent
  * with a maximum size of 1 MB. Calling this method several
  * times overrides the file to be attached. The file has to

--- a/src/ios/IBGPlugin.m
+++ b/src/ios/IBGPlugin.m
@@ -408,6 +408,34 @@
 }
 
 /**
+ * Sets a minimum number of characters as a requirement for the comments field in the different report types.
+ * @param {CDVInvokedUrlCommand*} command
+ *        The command sent from JavaScript
+*/
+- (void)setCommentMinimumCharacterCount:(CDVInvokedUrlCommand*)command
+{
+    CDVPluginResult* result;
+    NSNumber* limit = [command argumentAtIndex:0];
+    NSArray* reportTypes = [command argumentAtIndex:1];
+    IBGBugReportingReportType parsedTypes = 0;
+
+    if (![reportTypes count]) {
+        parsedTypes = ([self parseBugReportingReportType:@"bug"] | [self parseBugReportingReportType:@"feedback"] | [self parseBugReportingReportType:@"question"]);
+    }
+    else {
+        for (NSString* type in reportTypes) {
+            parsedTypes |= [self parseBugReportingReportType:type];
+        }
+    }
+
+    [IBGBugReporting setCommentMinimumCharacterCountForReportTypes:parsedTypes withLimit:limit.intValue];
+    result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    [self.commandDelegate sendPluginResult:result callbackId:[command callbackId]];
+
+}
+
+
+/**
  * Attaches a new copy of this file with each bug report sent
  * with a maximum size of 1 MB. Calling this method several
  * times overrides the file to be attached. The file has to

--- a/src/modules/BugReporting.ts
+++ b/src/modules/BugReporting.ts
@@ -300,5 +300,21 @@ namespace BugReporting {
   ) => {
     exec("IBGPlugin", "setDisclaimerText", [text], success, error);
   };
+
+  /**
+   * Sets a minimum number of characters as a requirement for the comments field in the different report types.
+   * @param limit an integer number of characters.
+   * @param reportTypes an optional an array of reportType. If it's not passed, the limit will apply to all report types.
+   * @param success callback on function success.
+   * @param error callback on function error.
+  */
+  export const setCommentMinimumCharacterCount = (
+    limit: number, 
+    reportTypes?: reportType[],
+    success?: () => void,
+    error?: (err: any) => void 
+  ) => {
+    exec("IBGPlugin", "setCommentMinimumCharacterCount", [limit, reportTypes], success, error);
+  };
 }
 export = BugReporting;

--- a/src/modules/BugReporting.ts
+++ b/src/modules/BugReporting.ts
@@ -286,5 +286,19 @@ namespace BugReporting {
       error
     );
   };
+
+  /**
+   * Adds a disclaimer text within the bug reporting form, which can include hyperlinked text.
+   * @param text a String of the disclaimer text.
+   * @param success callback on function success.
+   * @param error callback on function error.
+  */
+  export const setDisclaimerText = (
+    text: string, 
+    success?: () => void,
+    error?: (err: any) => void 
+  ) => {
+    exec("IBGPlugin", "setDisclaimerText", [text], success, error);
+  };
 }
 export = BugReporting;


### PR DESCRIPTION
## Description of the change

- Adds `BugReporting.setDisclaimerText` API
- Adds `BugReporting.setCommentMinimumCharacterCount` API

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request 
