### PR TITLE
[MOB-11723] Add more String Keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,15 @@
   * portuguesePortugal
   * romanian
   * slovak
-
+* Adds new string keys:
+  * insufficientContentMessage
+  * insufficientContentTitle (iOS)
+  * screenRecording
+* Adds missing mapping for the below string keys on Android:
+  * audio
+  * image
+  * messagesNotificationAndOthers
+  * okButtonTitle
 ## 11.3.0 (2022-10-05)
 
 * Bumps Instabug Android SDK to v11.5.1

--- a/src/android/util/ArgsRegistry.java
+++ b/src/android/util/ArgsRegistry.java
@@ -69,6 +69,7 @@ public class ArgsRegistry {
         put("reportBug", Key.REPORT_BUG);
         put("reportFeedback", Key.REPORT_FEEDBACK);
         put("conversationsHeaderTitle", Key.CONVERSATIONS_LIST_TITLE);
+        put("okButtonTitle", Key.BUG_ATTACHMENT_DIALOG_OK_BUTTON);
         put("addVoiceMessage", Key.ADD_VOICE_MESSAGE);
         put("addImageFromGallery", Key.ADD_IMAGE_FROM_GALLERY);
         put("addExtraScreenshot", Key.ADD_EXTRA_SCREENSHOT);
@@ -77,6 +78,10 @@ public class ArgsRegistry {
         put("recordingMessageToHoldText", Key.VOICE_MESSAGE_PRESS_AND_HOLD_TO_RECORD);
         put("recordingMessageToReleaseText", Key.VOICE_MESSAGE_RELEASE_TO_ATTACH);
         put("thankYouText", Key.SUCCESS_DIALOG_HEADER);
+        put("audio", Key.CHATS_TYPE_AUDIO);
+        put("image", Key.CHATS_TYPE_IMAGE);
+        put("screenRecording", Key.CHATS_TYPE_VIDEO);
+        put("messagesNotificationAndOthers", Key.CHATS_MULTIPLE_MESSAGE_NOTIFICATION);
         put("videoPressRecord", Key.VIDEO_RECORDING_FAB_BUBBLE_HINT);
         put("conversationTextFieldHint", Key.CONVERSATION_TEXT_FIELD_HINT);
         put("thankYouAlertText", Key.REPORT_SUCCESSFULLY_SENT);
@@ -111,6 +116,8 @@ public class ArgsRegistry {
         put("reproStepsListDescription", Key.REPRO_STEPS_LIST_DESCRIPTION);
         put("reproStepsListEmptyStateDescription", Key.REPRO_STEPS_LIST_EMPTY_STATE_DESCRIPTION);
         put("reproStepsListItemTitle", Key.REPRO_STEPS_LIST_ITEM_NUMBERING_TITLE);
+
+        put("insufficientContentMessage", Key.COMMENT_FIELD_INSUFFICIENT_CONTENT);
     }};
 
     public static final ArgsMap<State> reproStepsModes = new ArgsMap<State>() {{

--- a/src/ios/util/ArgsRegistry.m
+++ b/src/ios/util/ArgsRegistry.m
@@ -70,8 +70,8 @@
         @"cancelButtonTitle": kIBGCancelButtonTitleStringName,
         @"thankYouText": kIBGThankYouAlertTitleStringName,
         @"audio": kIBGAudioStringName,
-        @"screenRecording": kIBGScreenRecordingStringName,
         @"image": kIBGImageStringName,
+        @"screenRecording": kIBGScreenRecordingStringName,
         @"surveyEnterYourAnswer": kIBGSurveyEnterYourAnswerTextPlaceholder,
         @"videoPressRecord": kIBGVideoPressRecordTitle,
         @"collectingDataText": kIBGCollectingDataText,
@@ -106,7 +106,10 @@
         @"reproStepsListHeader": kIBGReproStepsListTitle,
         @"reproStepsListDescription": kIBGReproStepsListHeader,
         @"reproStepsListEmptyStateDescription": kIBGReproStepsListEmptyStateLabel,
-        @"reproStepsListItemTitle": kIBGReproStepsListItemName
+        @"reproStepsListItemTitle": kIBGReproStepsListItemName,
+
+        @"insufficientContentMessage": kIBGInsufficientContentMessageStringName,
+        @"insufficientContentTitle": kIBGInsufficientContentTitleStringName,
     };
 }
 

--- a/src/modules/ArgsRegistry.ts
+++ b/src/modules/ArgsRegistry.ts
@@ -57,6 +57,7 @@ namespace ArgsRegistry {
     thankYouText = "thankYouText",
     audio = "audio",
     image = "image",
+    screenRecording = "screenRecording",
     team = "team",
     messagesNotification = "messagesNotification",
     messagesNotificationAndOthers = "messagesNotificationAndOthers",
@@ -89,6 +90,8 @@ namespace ArgsRegistry {
     reproStepsListDescription = "reproStepsListDescription",
     reproStepsListEmptyStateDescription = "reproStepsListEmptyStateDescription",
     reproStepsListItemTitle = "reproStepsListItemTitle",
+    insufficientContentMessage = "insufficientContentMessage",
+    insufficientContentTitle = "insufficientContentTitle",
   }
 
   export enum reproStepsMode {


### PR DESCRIPTION
## Description of the change

- Adds new string keys and missing mappings on Android.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request 
